### PR TITLE
Add Crystal ball

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,12 +12,14 @@ SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 [compat]
 Distributions = "0.25.120"
 Polynomials = "4.0.19"
+QuadGK = "2.11.2"
 Random = "1.11.0"
 SpecialFunctions = "2.5.1"
 Test = "1.11.0"
 
 [extras]
+QuadGK = "1fd47b50-473d-5c70-9696-f719f8f3bcdc"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["Test", "QuadGK"]

--- a/src/DistributionsHEP.jl
+++ b/src/DistributionsHEP.jl
@@ -3,7 +3,9 @@ module DistributionsHEP
 using Random
 using Distributions
 using SpecialFunctions
-import Distributions: @check_args
+
+import Distributions: pdf, cdf, @check_args
+export pdf, cdf
 
 export Chebyshev
 include("chebychev.jl")

--- a/src/DistributionsHEP.jl
+++ b/src/DistributionsHEP.jl
@@ -2,9 +2,16 @@ module DistributionsHEP
 
 using Random
 using Distributions
+using SpecialFunctions
 import Distributions: @check_args
 
+export Chebyshev
 include("chebychev.jl")
+
+export ArgusBG
 include("argusBG.jl")
+
+export CrystalBall
+include("crystalball.jl")
 
 end

--- a/src/crystalball.jl
+++ b/src/crystalball.jl
@@ -1,0 +1,63 @@
+# Common parameter validation
+function _check_crystalball_params(σ::T, α::T, n::T) where {T<:Real}
+    σ > zero(T) || error("σ (scale) must be positive.")
+    α > zero(T) || error("α (transition point) must be positive.")
+    n > one(T) || error("n (power-law exponent) must be greater than 1.")
+end
+
+struct CrystalBall{T<:Real} <: ContinuousUnivariateDistribution
+    μ::T
+    σ::T
+    α::T
+    n::T
+    # Precomputed constants for PDF calculation
+    norm_const::T # Normalization constant N
+    A_const::T    # Tail parameter A
+    B_const::T    # Tail parameter B
+
+    function CrystalBall(μ::T, σ::T, α::T, n::T) where {T<:Real}
+        _check_crystalball_params(σ, α, n)
+        # absα is effectively α due to the check α > 0
+        C = n / α / (n - 1) * exp(-α^2 / 2)
+        D_val = sqrt(T(π) / 2) * (one(T) + erf(α / sqrt(T(2))))
+        N = one(T) / (σ * (C + D_val))
+
+        A = (n / α)^n * exp(-α^2 / 2)
+        B = n / α - α
+        new{T}(μ, σ, α, n, N, A, B)
+    end
+end
+
+function Distributions.pdf(d::CrystalBall{T}, x::Real) where {T<:Real}
+    x̂ = (x - d.μ) / d.σ
+    if x̂ > -d.α # Gaussian part
+        return d.norm_const * exp(-x̂^2 / 2)
+    else # Power-law tail part
+        return d.norm_const * d.A_const * (d.B_const - x̂)^(-d.n)
+    end
+end
+
+function Distributions.cdf(d::CrystalBall{T}, x::Real) where {T<:Real}
+    x̂ = (x - d.μ) / d.σ
+
+    # Integral of the tail from -Inf to -α
+    # This is σ * C from the constructor's N calculation, divided by N itself to get the unnormalized integral, then multiplied by d.norm_const
+    # Integral_tail_part = (d.n / d.α / (d.n - 1) * exp(-d.α^2 / 2))
+    # Simplified: this is the value of the tail part of CDF at x̂ = -d.α
+    cdf_at_minus_alpha = d.norm_const * d.A_const / (d.n - 1) * (d.B_const - (-d.α))^(1 - d.n)
+
+    if x̂ <= -d.α
+        # Power-law tail part: integral of d.norm_const * d.A_const * (d.B_const - t)^(-d.n) dt
+        # from -Inf to x̂
+        # Indefinite integral is d.norm_const * d.A_const / (d.n-1) * (d.B_const - t)^(1-d.n)
+        # As t -> -Inf, (d.B_const - t)^(1-d.n) -> 0 because 1-d.n < 0.
+        return d.norm_const * d.A_const / (d.n - 1) * (d.B_const - x̂)^(1 - d.n)
+    else
+        # Gaussian part: CDF_at_minus_alpha + integral of d.norm_const * exp(-t^2/2) dt from -α to x̂
+        # Integral of exp(-t^2/2) from -α to x̂ is
+        # sqrt(π/2) * (erf(x̂/√2) - erf(-α/√2))
+        # = sqrt(π/2) * (erf(x̂/√2) + erf(α/√2))
+        integral_gaussian_part = sqrt(T(π) / 2) * (erf(x̂ / sqrt(T(2))) + erf(d.α / sqrt(T(2))))
+        return cdf_at_minus_alpha + d.norm_const * d.σ * integral_gaussian_part
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,2 @@
-using DistributionsHEP
-using Test
 
-@test true
+include("test-chebychev.jl")

--- a/test/test-chebychev.jl
+++ b/test/test-chebychev.jl
@@ -1,0 +1,47 @@
+using SpecialFunctions
+using DistributionsHEP
+using Distributions
+using QuadGK
+using Test
+
+d = CrystalBall(0.0, 1.0, 1.0, 1.6)
+
+@testset "CrystalBall continuity on merging point" begin
+    x_merge = -d.α * d.σ + d.μ
+    pdf_value_left = pdf(d, x_merge + 1e-5) # just above the transition point
+    pdf_value_right = pdf(d, x_merge - 1e-5) # just below the transition point
+    @test isapprox(pdf_value_left, pdf_value_right; atol=1e-5) # should be continuous
+end
+
+# for visual inspection
+# using Plots
+# plot(x -> pdf(d, x), -10, 10,
+#     label="Crystal Ball PDF",
+#     xlabel="x", ylabel="PDF",
+#     title="Crystal Ball Distribution")
+
+# check integral
+numerical_integral = quadgk(x -> pdf(d, x), -Inf, Inf)[1]
+@show numerical_integral
+@test isapprox(numerical_integral, 1.0; atol=1e-7)
+
+# # for visual inspection
+# using Plots
+# plot(x -> cdf(d, x), -10, 10,
+#     label="Crystal Ball CDF",
+#     xlabel="x", ylabel="CDF",
+# title="Crystal Ball Distribution")
+
+# Continuity check for CDF
+@testset "CrystalBall CDF continuity on merging point" begin
+    x_merge = -d.α * d.σ + d.μ
+    cdf_value_left = cdf(d, x_merge + 1e-6) # just above the transition point
+    cdf_value_right = cdf(d, x_merge - 1e-6) # just below the transition point
+    @show cdf_value_left, cdf_value_right
+    @test isapprox(cdf_value_left, cdf_value_right; atol=1e-5) # should be continuous
+end
+
+@testset "CrystalBall CDF properties" begin
+    @test cdf(d, -100) < 0.1
+    @test isapprox(cdf(d, d.μ + 5 * d.σ), 1; atol=1e-5)
+end

--- a/test/test-chebychev.jl
+++ b/test/test-chebychev.jl
@@ -45,3 +45,23 @@ end
     @test cdf(d, -100) < 0.1
     @test isapprox(cdf(d, d.μ + 5 * d.σ), 1; atol=1e-5)
 end
+
+# # for visual inspection
+# using Plots
+# plot(x -> cdf(d, x), -10, 10,
+#     label="Crystal Ball CDF",
+#     xlabel="x", ylabel="CDF",
+#     title="Crystal Ball Distribution")
+# 
+# plot(x -> quantile(d, x), 0.2, 0.99,
+#     label="Crystal Ball Quantile",
+#     xlabel="x", ylabel="Quantile",
+#     title="Crystal Ball Distribution")
+# 
+
+@testset "CrystalBall quantile properties" begin
+    # gaussian part
+    @test quantile(d, cdf(d, 0.9)) ≈ 0.9
+    # in the power-law tail
+    @test quantile(d, cdf(d, 0.1)) ≈ 0.1
+end


### PR DESCRIPTION
# Add CrystalBall Distribution

Closes #2 

## Description:

This pull request introduces the Crystal Ball distribution. The is commonly used in high-energy physics to model resolution functions and other lossy processes, featuring a Gaussian core with a power-law tail.

- [x] Docstrings
- [x] Tests

## Implemented Methods:

- `Distributions.pdf(d::CrystalBall, x::Real)`: Computes the probability density function.
- `Distributions.cdf(d::CrystalBall, x::Real)`: Computes the cumulative distribution function. The implementation ensures continuity at the transition point between the Gaussian core and the power-law tail.
- `Distributions.quantile(d::CrystalBall, p::Real)`: Computes the quantile (inverse CDF) "analytically". It is a default fall back for sampling (`rand`).


## Future Considerations (Optional):
- add`RightCrystalBall`: currently can be obtained with Affine Transformation x(-1)
-`DoubleCrystalBall` 
