### PR TITLE
Promote mixed real distribution parameters

### DIFF
--- a/src/argusBG.jl
+++ b/src/argusBG.jl
@@ -20,6 +20,8 @@ struct StandardArgusBG{T <: Real} <: ContinuousUnivariateDistribution
     end
 end
 
+StandardArgusBG(c::Real, p::Real) = StandardArgusBG(promote(c, p)...)
+
 """
     ArgusBG(c, p, a, b)
 
@@ -51,8 +53,9 @@ d = ArgusBG(-2.0, 0.5, 0, 1)
 d = ArgusBG(-1.5, 1.0, 0, 10)
 ```
 """
-function ArgusBG(c::T, p = T(0.5), a = 0.0, b = 1.0) where {T <: Real}
-    return StandardArgusBG(c, p) * (b - a) + a
+function ArgusBG(c::Real, p::Real = 0.5, a::Real = 0.0, b::Real = 1.0)
+    ρ = StandardArgusBG(c, p)
+    return ρ * (b - a) + a
 end
 
 # Standardized ARGUS PDF on [0,1]

--- a/src/chebyshev.jl
+++ b/src/chebyshev.jl
@@ -54,7 +54,7 @@ d = Chebyshev([1.0, 1.0], 0, 10)
 d = Chebyshev([4.0, 0.0, 1.0], -5, 5)
 ```
 """
-function Chebyshev(coeffs, a::T = -1.0, b::T = 1.0) where {T <: Real}
+function Chebyshev(coeffs, a::Real = -1.0, b::Real = 1.0)
     return StandardChebyshev(coeffs) * (b - a) / 2 + (a + b) / 2
 end
 
@@ -75,4 +75,3 @@ function Base.rand(rng::AbstractRNG, d::StandardChebyshev)
     end
     return x
 end
-

--- a/src/crystalball.jl
+++ b/src/crystalball.jl
@@ -68,6 +68,9 @@ struct CrystalBall{T<:Real} <: ContinuousUnivariateDistribution
     end
 end
 
+# Convenience constructor
+CrystalBall(μ::Real, σ::Real, α::Real, n::Real) = CrystalBall(promote(μ, σ, α, n)...)
+
 function Distributions.pdf(d::CrystalBall{T}, x::Real) where {T<:Real}
     x > d.tail.x0 && return d.norm_const * pdf(d.gauss, x)
 
@@ -113,5 +116,4 @@ Distributions.minimum(d::CrystalBall{T}) where {T<:Real} = T(-Inf)
 # Distributions.jl interface methods
 Distributions.location(d::CrystalBall) = d.gauss.μ
 Distributions.scale(d::CrystalBall) = d.gauss.σ
-
 

--- a/src/double-sided-crystal-ball.jl
+++ b/src/double-sided-crystal-ball.jl
@@ -84,6 +84,10 @@ struct DoubleCrystalBall{T<:Real} <: ContinuousUnivariateDistribution
     end
 end
 
+# Convenience constructor
+DoubleCrystalBall(μ::Real, σ::Real, αL::Real, nL::Real, αR::Real, nR::Real) =
+    DoubleCrystalBall(promote(μ, σ, αL, nL, αR, nR)...)
+
 """
     _compute_transition_cdf_values(d::DoubleCrystalBall)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,4 +9,5 @@ using Test
     include("test-bifurcated-gaussian.jl")
     include("test-double-sided-bifurcated-crystal-ball.jl")
     include("test-double-sided-bifurcated-crystal-ball-das.jl")
+    include("test-constructor-promotion.jl")
 end

--- a/test/test-argusBG.jl
+++ b/test/test-argusBG.jl
@@ -43,6 +43,18 @@ d_set = [
             @test minimum(d) == support(d).lb
             @test maximum(d) == support(d).ub
         end
+
+        d_mixed = ArgusBG(-2.0f0, 0.8, -1.0f0, 3.0)
+        @test partype(d_mixed) == Float64
+        @test minimum(d_mixed) == -1.0
+        @test maximum(d_mixed) == 3.0
+
+        d_float32_shape = ArgusBG(-2.0f0, 0.8f0, -1.0, 3.0)
+        @test partype(d_float32_shape.ρ) == Float32
+        @test partype(d_float32_shape) == Float64
+
+        d_integer_c = ArgusBG(-2)
+        @test partype(d_integer_c.ρ) == Float64
     end
 
     @testset "PDF properties" begin
@@ -94,5 +106,3 @@ d_set = [
         end
     end
 end
-
-

--- a/test/test-constructor-promotion.jl
+++ b/test/test-constructor-promotion.jl
@@ -1,0 +1,27 @@
+using DistributionsHEP
+using Distributions
+using Test
+
+@testset "Mixed parameter constructors" begin
+    distributions = [
+        Chebyshev([1.0, 0.2], -1.0f0, 1.0),
+        ArgusBG(-2.0f0, 0.8, -1.0f0, 3.0),
+        CrystalBall(0.0f0, 1.0, 1.5, 2.5),
+        DoubleCrystalBall(0.0f0, 1.0, 1.5, 2.5, 2.0, 3.0),
+        HyperbolicSecant(0.0f0, 1.0),
+        BifurcatedGaussian(0.0f0, 1.0, 0.2),
+        DoubleSidedBifurcatedCrystalBall(0.0f0, 1.0, 0.2, 1.5, 2.5, 2.0, 3.0),
+        DoubleSidedBifurcatedCrystalBallDas(0.0f0, 1.0, 0.2, 1.5, 2.5, 2.0),
+    ]
+
+    for d in distributions
+        x = (minimum(d) + maximum(d)) / 2
+        isfinite(x) || (x = zero(partype(d)))
+        @test isfinite(pdf(d, x))
+        @test zero(partype(d)) <= cdf(d, x) <= one(partype(d))
+    end
+
+    d_argus = ArgusBG(-2.0f0, 0.8f0, -1.0, 3.0)
+    @test partype(d_argus.ρ) == Float32
+    @test partype(d_argus) == Float64
+end

--- a/test/test-crystalball.jl
+++ b/test/test-crystalball.jl
@@ -104,13 +104,17 @@ using Test
     @testset "Type stability" begin
         d_float64 = CrystalBall(0.0, 1.0, 2.0, 3.0)
         d_float32 = CrystalBall(0.0f0, 1.0f0, 2.0f0, 3.0f0)
+        d_mixed = CrystalBall(0.0f0, 1.0, 2.0, 3.0)
 
         @test pdf(d_float64, 0.0) isa Float64
         @test pdf(d_float32, 0.0f0) isa Float32
+        @test pdf(d_mixed, 0.0) isa Float64
         @test cdf(d_float64, 0.0) isa Float64
         @test cdf(d_float32, 0.0f0) isa Float32
+        @test cdf(d_mixed, 0.0) isa Float64
         @test quantile(d_float64, 0.5) isa Float64
         @test quantile(d_float32, 0.5f0) isa Float32
+        @test quantile(d_mixed, 0.5) isa Float64
     end
 
     @testset "Support interface" begin

--- a/test/test-double-sided-crystal-ball.jl
+++ b/test/test-double-sided-crystal-ball.jl
@@ -132,13 +132,17 @@ d = DoubleCrystalBall(0.0, 1.0, 1.5, 2.0, 2.0, 3.0)
     @testset "Type stability" begin
         d_float64 = DoubleCrystalBall(0.0, 1.0, 1.5, 2.0, 2.0, 3.0)
         d_float32 = DoubleCrystalBall(0.0f0, 1.0f0, 1.5f0, 2.0f0, 2.0f0, 3.0f0)
+        d_mixed = DoubleCrystalBall(0.0f0, 1.0, 1.5, 2.0, 2.0, 3.0)
 
         @test pdf(d_float64, 0.0) isa Float64
         @test pdf(d_float32, 0.0f0) isa Float32
+        @test pdf(d_mixed, 0.0) isa Float64
         @test cdf(d_float64, 0.0) isa Float64
         @test cdf(d_float32, 0.0f0) isa Float32
+        @test cdf(d_mixed, 0.0) isa Float64
         @test quantile(d_float64, 0.5) isa Float64
         @test quantile(d_float32, 0.5f0) isa Float32
+        @test quantile(d_mixed, 0.5) isa Float64
     end
 
     @testset "Support interface" begin


### PR DESCRIPTION
## Summary
- add promote-based outer constructors for CrystalBall, DoubleCrystalBall, ArgusBG, and Chebyshev interval bounds
- keep inner constructors responsible for validation and cached constant construction
- add regression coverage for mixed real constructor arguments across exported distributions

Closes #45.

## Checks
- [x] Tests are passed
- [x] No need to update docs

Note: ReverseDiff is not in this package environment, so the exact issue reproducer was not run locally without adding a new dependency.