### PR TITLE
Add ExtendedMixtureModel for yield-weighted fits

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,6 +11,7 @@ SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 
 [compat]
 Distributions = "0.25"
+LinearAlgebra = "1"
 Polynomials = "4"
 QuadGK = "2"
 Random = "1"
@@ -19,8 +20,9 @@ Test = "1"
 julia = "1"
 
 [extras]
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 QuadGK = "1fd47b50-473d-5c70-9696-f719f8f3bcdc"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "QuadGK"]
+test = ["Test", "QuadGK", "LinearAlgebra"]

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ any distributions requiring numerical integration can be wrapped ith [`Numerical
 - **CrystalBall**, **DoubleCrystalBall**: One-sided and two-sided Crystal Ball distribution with Gaussian core and power-law tail
 - **HyperbolicSecant**: Hyperbolic secant distribution with location-scale family similar to normal distribution but with fatter tails
 - **BifurcatedGaussian**: Asymmetric Gaussian distribution with different scale parameters on left and right sides
+- **ExtendedMixtureModel**: Mixture-like model for extended likelihood fits where component weights are expected yields instead of normalized probabilities
 
 Mathematical derivations for Crystal Ball distributions are in [`docs/CrystalBallMath.md`](docs/CrystalBallMath.md), formulas for ARGUS background distribution are in [`docs/ArgusBG.md`](docs/ArgusBG.md), and derivations for Bifurcated Gaussian (including skewness formula) are in [`docs/BifurcatedGaussianMath.md`](docs/BifurcatedGaussianMath.md).
 
@@ -48,6 +49,34 @@ rand(cheb)
 ```
 
 The rest of the interface (`pdf`, `cdf`, `rand`, etc.) follows the standard `Distributions.jl` API.
+
+### Extended mixture models
+
+`ExtendedMixtureModel` is useful for extended likelihood fits where fitted
+component weights are expected event yields, not normalized mixture fractions.
+For components `f_k` and yields `y_k`, call the model directly to evaluate
+
+```math
+f_{\mathrm{ext}}(x) = \sum_k y_k f_k(x).
+```
+
+```julia
+using Distributions
+using DistributionsHEP
+
+components = [Normal(-1.0, 0.5), Normal(1.0, 0.25)]
+model = ExtendedMixtureModel(components, [20.0, 5.0])
+
+model(0.1)
+extended_negative_log_likelihood(model, [-1.0, -0.5, 0.9])
+```
+
+`ExtendedMixtureModel` deliberately does not define `pdf(model, x)` or
+`logpdf(model, x)`, because the yield-weighted density is not normalized.
+Use `MixtureModel(model)` when a normalized mixture is needed. The helper
+accessors `yields(model)` and `total_yield(model)` are available as
+`DistributionsHEP.yields` and `DistributionsHEP.total_yield`, or by importing
+them explicitly.
 
 ## Contributing
 

--- a/src/DistributionsHEP.jl
+++ b/src/DistributionsHEP.jl
@@ -39,4 +39,7 @@ export DoubleSidedBifurcatedCrystalBallDas
 include("exponential-tail.jl")
 include("double-sided-bifurcated-crystal-ball-das.jl")
 
+export ExtendedMixtureModel, yields, total_yield, marginalize, extended_negative_log_likelihood
+include("extended-mixture-model.jl")
+
 end

--- a/src/DistributionsHEP.jl
+++ b/src/DistributionsHEP.jl
@@ -39,7 +39,7 @@ export DoubleSidedBifurcatedCrystalBallDas
 include("exponential-tail.jl")
 include("double-sided-bifurcated-crystal-ball-das.jl")
 
-export ExtendedMixtureModel, yields, total_yield, marginalize, extended_negative_log_likelihood
+export ExtendedMixtureModel, yields, total_yield, extended_negative_log_likelihood
 include("extended-mixture-model.jl")
 
 end

--- a/src/DistributionsHEP.jl
+++ b/src/DistributionsHEP.jl
@@ -39,7 +39,7 @@ export DoubleSidedBifurcatedCrystalBallDas
 include("exponential-tail.jl")
 include("double-sided-bifurcated-crystal-ball-das.jl")
 
-export ExtendedMixtureModel, yields, total_yield, extended_negative_log_likelihood
+export ExtendedMixtureModel, extended_negative_log_likelihood
 include("extended-mixture-model.jl")
 
 end

--- a/src/extended-mixture-model.jl
+++ b/src/extended-mixture-model.jl
@@ -72,7 +72,8 @@ end
     extended_negative_log_likelihood(model, data)
 
 Evaluate `-sum(log(model(x)) for x in data) + total_yield(model)`.
-For multivariate models, an `AbstractMatrix` is interpreted column-wise.
+For generic iterables, data points are taken as `x in data`. For multivariate
+models with `data::AbstractMatrix`, data points are taken as `x in eachcol(data)`.
 """
 function extended_negative_log_likelihood(d::ExtendedMixtureModel, data)
     nll = zero(float(total_yield(d)))

--- a/src/extended-mixture-model.jl
+++ b/src/extended-mixture-model.jl
@@ -49,6 +49,43 @@ yields(d::ExtendedMixtureModel) = d.yields
 """Return `sum(yields(d))` for an `ExtendedMixtureModel`."""
 total_yield(d::ExtendedMixtureModel) = sum(yields(d))
 
+function _union_minimum(components::AbstractVector{<:Distribution})
+    first_component = first(components)
+    if Distributions.variate_form(typeof(first_component)) == Univariate
+        return minimum(minimum(c) for c in components)
+    end
+    return mapreduce(minimum, (x, y) -> min.(x, y), components)
+end
+
+function _union_maximum(components::AbstractVector{<:Distribution})
+    first_component = first(components)
+    if Distributions.variate_form(typeof(first_component)) == Univariate
+        return maximum(maximum(c) for c in components)
+    end
+    return mapreduce(maximum, (x, y) -> max.(x, y), components)
+end
+
+function _union_support(components::AbstractVector{<:Distribution})
+    return Distributions.RealInterval.(_union_minimum(components), _union_maximum(components))
+end
+
+Distributions.support(d::Distributions.Product) =
+    Distributions.RealInterval.(minimum(d), maximum(d))
+
+Distributions.support(d::MvNormal) =
+    Distributions.RealInterval.(minimum(d), maximum(d))
+
+Distributions.minimum(d::Distributions.AbstractMixtureModel) = _union_minimum(components(d))
+Distributions.maximum(d::Distributions.AbstractMixtureModel) = _union_maximum(components(d))
+Distributions.support(d::Distributions.AbstractMixtureModel) = _union_support(components(d))
+
+Distributions.minimum(d::MixtureModel) = _union_minimum(components(d))
+Distributions.maximum(d::MixtureModel) = _union_maximum(components(d))
+
+Distributions.minimum(d::ExtendedMixtureModel) = _union_minimum(components(d))
+Distributions.maximum(d::ExtendedMixtureModel) = _union_maximum(components(d))
+Distributions.support(d::ExtendedMixtureModel) = _union_support(components(d))
+
 function (::Type{MixtureModel})(d::ExtendedMixtureModel)
     total = total_yield(d)
     total > zero(total) ||

--- a/src/extended-mixture-model.jl
+++ b/src/extended-mixture-model.jl
@@ -29,9 +29,6 @@ struct ExtendedMixtureModel{
 end
 
 function ExtendedMixtureModel(components::AbstractVector{C}, yields::AbstractVector{<:Real}) where {C<:Distribution}
-    length(components) == length(yields) || throw(ArgumentError("ExtendedMixtureModel: length mismatch"))
-    !isempty(components) || throw(ArgumentError("ExtendedMixtureModel: components and yields must be non-empty"))
-
     VF = Distributions.variate_form(C)
     VS = Distributions.value_support(C)
     T = promote_type(Float64, eltype(yields))

--- a/src/extended-mixture-model.jl
+++ b/src/extended-mixture-model.jl
@@ -49,32 +49,6 @@ yields(d::ExtendedMixtureModel) = d.yields
 """Return `sum(yields(d))` for an `ExtendedMixtureModel`."""
 total_yield(d::ExtendedMixtureModel) = sum(yields(d))
 
-factor(d::Distributions.Product, k::Int) = d.v[k]
-
-"""
-    marginalize(model, k)
-
-Return the exact one-dimensional marginal distribution for dimension `k` when
-the model is built from independent product components and mixtures.
-"""
-function marginalize(d::Distributions.Product, k::Int)
-    return factor(d, k)
-end
-
-function marginalize(d::Distributions.AbstractMixtureModel, k::Int)
-    return MixtureModel(
-        [marginalize(c, k) for c in components(d)],
-        probs(d),
-    )
-end
-
-function marginalize(d::ExtendedMixtureModel, k::Int)
-    return ExtendedMixtureModel(
-        [marginalize(c, k) for c in components(d)],
-        yields(d),
-    )
-end
-
 function (::Type{MixtureModel})(d::ExtendedMixtureModel)
     total = total_yield(d)
     total > zero(total) ||

--- a/src/extended-mixture-model.jl
+++ b/src/extended-mixture-model.jl
@@ -1,0 +1,120 @@
+"""
+    ExtendedMixtureModel(components, yields)
+
+Mixture-like distribution whose weights are expected event yields instead of
+normalized probabilities. For components `f_k` and yields `y_k`, the density is
+`sum(y_k * f_k(x) for k)`. This is the density term used in extended
+likelihood fits where the fitted parameters are component yields.
+
+Yields must be non-negative and have the same length as `components`.
+Use `MixtureModel(model)` to convert to the corresponding normalized mixture.
+"""
+struct ExtendedMixtureModel{
+    VF<:VariateForm,
+    VS<:ValueSupport,
+    C<:Distribution,
+    T<:Real,
+} <: Distribution{VF,VS}
+    components::Vector{C}
+    yields::Vector{T}
+
+    function ExtendedMixtureModel{VF,VS,C,T}(components::Vector{C}, yields::Vector{T}) where {VF,VS,C,T}
+        length(components) == length(yields) ||
+            throw(ArgumentError("ExtendedMixtureModel: $(length(components)) components vs $(length(yields)) yields"))
+        return new{VF,VS,C,T}(components, yields)
+    end
+end
+
+function ExtendedMixtureModel(components::AbstractVector{C}, yields::AbstractVector{<:Real}) where {C<:Distribution}
+    length(components) == length(yields) || throw(ArgumentError("ExtendedMixtureModel: length mismatch"))
+    any(y -> y < zero(y), yields) && throw(ArgumentError("ExtendedMixtureModel: yields must be non-negative"))
+
+    VF = Distributions.variate_form(C)
+    VS = Distributions.value_support(C)
+    T = promote_type(Float64, eltype(yields))
+    return ExtendedMixtureModel{VF,VS,C,T}(collect(components), T.(yields))
+end
+
+Distributions.ncomponents(d::ExtendedMixtureModel) = length(d.components)
+Distributions.components(d::ExtendedMixtureModel) = d.components
+Distributions.component(d::ExtendedMixtureModel, k::Int) = d.components[k]
+Distributions.component_type(d::ExtendedMixtureModel{VF,VS,C}) where {VF,VS,C} = C
+
+"""Return the expected event yields of an `ExtendedMixtureModel`."""
+yields(d::ExtendedMixtureModel) = d.yields
+
+"""Return `sum(yields(d))` for an `ExtendedMixtureModel`."""
+total_yield(d::ExtendedMixtureModel) = sum(yields(d))
+
+factor(d::Distributions.Product, k::Int) = d.v[k]
+
+"""
+    marginalize(model, k)
+
+Return the exact one-dimensional marginal distribution for dimension `k` when
+the model is built from independent product components and mixtures.
+"""
+function marginalize(d::Distributions.Product, k::Int)
+    return factor(d, k)
+end
+
+function marginalize(d::Distributions.AbstractMixtureModel, k::Int)
+    return MixtureModel(
+        [marginalize(c, k) for c in components(d)],
+        probs(d),
+    )
+end
+
+function marginalize(d::ExtendedMixtureModel, k::Int)
+    return ExtendedMixtureModel(
+        [marginalize(c, k) for c in components(d)],
+        yields(d),
+    )
+end
+
+function (::Type{MixtureModel})(d::ExtendedMixtureModel)
+    total = total_yield(d)
+    total > zero(total) ||
+        throw(ArgumentError("MixtureModel(::ExtendedMixtureModel): total yield must be positive"))
+    return MixtureModel(components(d), yields(d) ./ total)
+end
+
+function Distributions.pdf(d::ExtendedMixtureModel{Univariate}, x::Real)
+    return sum(y * pdf(component(d, i), x) for (i, y) in enumerate(yields(d)) if !iszero(y))
+end
+
+function Distributions.pdf(d::ExtendedMixtureModel{Multivariate}, x::AbstractVector{<:Real})
+    return sum(y * pdf(component(d, i), x) for (i, y) in enumerate(yields(d)) if !iszero(y))
+end
+
+function Distributions.logpdf(d::ExtendedMixtureModel{Univariate}, x::Real)
+    density = pdf(d, x)
+    return density <= zero(density) ? -Inf : log(density)
+end
+
+function Distributions.logpdf(d::ExtendedMixtureModel{Multivariate}, x::AbstractVector{<:Real})
+    density = pdf(d, x)
+    return density <= zero(density) ? -Inf : log(density)
+end
+
+"""
+    extended_negative_log_likelihood(model, data)
+
+Evaluate `-sum(logpdf(model, x) for x in data) + total_yield(model)`.
+For multivariate models, an `AbstractMatrix` is interpreted column-wise.
+"""
+function extended_negative_log_likelihood(d::ExtendedMixtureModel, data)
+    nll = zero(float(total_yield(d)))
+    for x in data
+        lp = logpdf(d, x)
+        isfinite(lp) || return oftype(nll, Inf)
+        nll -= lp
+    end
+    return nll + total_yield(d)
+end
+
+function extended_negative_log_likelihood(d::ExtendedMixtureModel{Multivariate}, data::AbstractMatrix)
+    return extended_negative_log_likelihood(d, eachcol(data))
+end
+
+Base.length(d::ExtendedMixtureModel{Multivariate}) = length(d.components[1])

--- a/src/extended-mixture-model.jl
+++ b/src/extended-mixture-model.jl
@@ -46,24 +46,10 @@ yields(d::ExtendedMixtureModel) = d.yields
 """Return `sum(yields(d))` for an `ExtendedMixtureModel`."""
 total_yield(d::ExtendedMixtureModel) = sum(yields(d))
 
-function _union_minimum(components::AbstractVector{<:Distribution})
-    first_component = first(components)
-    if Distributions.variate_form(typeof(first_component)) == Univariate
-        return minimum(minimum(c) for c in components)
-    end
-    return mapreduce(minimum, (x, y) -> min.(x, y), components)
-end
-
-function _union_maximum(components::AbstractVector{<:Distribution})
-    first_component = first(components)
-    if Distributions.variate_form(typeof(first_component)) == Univariate
-        return maximum(maximum(c) for c in components)
-    end
-    return mapreduce(maximum, (x, y) -> max.(x, y), components)
-end
-
-Distributions.minimum(d::ExtendedMixtureModel) = _union_minimum(components(d))
-Distributions.maximum(d::ExtendedMixtureModel) = _union_maximum(components(d))
+Distributions.minimum(d::ExtendedMixtureModel) =
+    reduce((x, y) -> min.(x, y), minimum.(components(d)))
+Distributions.maximum(d::ExtendedMixtureModel) =
+    reduce((x, y) -> max.(x, y), maximum.(components(d)))
 Distributions.support(d::ExtendedMixtureModel) =
     Distributions.RealInterval.(minimum(d), maximum(d))
 

--- a/src/extended-mixture-model.jl
+++ b/src/extended-mixture-model.jl
@@ -31,7 +31,7 @@ end
 function ExtendedMixtureModel(components::AbstractVector{C}, yields::AbstractVector{<:Real}) where {C<:Distribution}
     VF = Distributions.variate_form(C)
     VS = Distributions.value_support(C)
-    T = promote_type(Float64, eltype(yields))
+    T = float(eltype(yields))
     return ExtendedMixtureModel{VF,VS,C,T}(collect(components), T.(yields))
 end
 

--- a/src/extended-mixture-model.jl
+++ b/src/extended-mixture-model.jl
@@ -60,11 +60,7 @@ function (::Type{MixtureModel})(d::ExtendedMixtureModel)
     return MixtureModel(components(d), yields(d) ./ total)
 end
 
-function (d::ExtendedMixtureModel{Univariate})(x::Real)
-    return sum(y * pdf(component(d, i), x) for (i, y) in enumerate(yields(d)) if !iszero(y))
-end
-
-function (d::ExtendedMixtureModel{Multivariate})(x::AbstractVector{<:Real})
+function (d::ExtendedMixtureModel)(x)
     return sum(y * pdf(component(d, i), x) for (i, y) in enumerate(yields(d)) if !iszero(y))
 end
 

--- a/src/extended-mixture-model.jl
+++ b/src/extended-mixture-model.jl
@@ -62,13 +62,10 @@ function _union_maximum(components::AbstractVector{<:Distribution})
     return mapreduce(maximum, (x, y) -> max.(x, y), components)
 end
 
-function _union_support(components::AbstractVector{<:Distribution})
-    return Distributions.RealInterval.(_union_minimum(components), _union_maximum(components))
-end
-
 Distributions.minimum(d::ExtendedMixtureModel) = _union_minimum(components(d))
 Distributions.maximum(d::ExtendedMixtureModel) = _union_maximum(components(d))
-Distributions.support(d::ExtendedMixtureModel) = _union_support(components(d))
+Distributions.support(d::ExtendedMixtureModel) =
+    Distributions.RealInterval.(minimum(d), maximum(d))
 
 function (::Type{MixtureModel})(d::ExtendedMixtureModel)
     total = total_yield(d)

--- a/src/extended-mixture-model.jl
+++ b/src/extended-mixture-model.jl
@@ -66,19 +66,6 @@ function _union_support(components::AbstractVector{<:Distribution})
     return Distributions.RealInterval.(_union_minimum(components), _union_maximum(components))
 end
 
-Distributions.support(d::Distributions.Product) =
-    Distributions.RealInterval.(minimum(d), maximum(d))
-
-Distributions.support(d::MvNormal) =
-    Distributions.RealInterval.(minimum(d), maximum(d))
-
-Distributions.minimum(d::Distributions.AbstractMixtureModel) = _union_minimum(components(d))
-Distributions.maximum(d::Distributions.AbstractMixtureModel) = _union_maximum(components(d))
-Distributions.support(d::Distributions.AbstractMixtureModel) = _union_support(components(d))
-
-Distributions.minimum(d::MixtureModel) = _union_minimum(components(d))
-Distributions.maximum(d::MixtureModel) = _union_maximum(components(d))
-
 Distributions.minimum(d::ExtendedMixtureModel) = _union_minimum(components(d))
 Distributions.maximum(d::ExtendedMixtureModel) = _union_maximum(components(d))
 Distributions.support(d::ExtendedMixtureModel) = _union_support(components(d))

--- a/src/extended-mixture-model.jl
+++ b/src/extended-mixture-model.jl
@@ -6,28 +6,31 @@ normalized probabilities. For components `f_k` and yields `y_k`, the density is
 `sum(y_k * f_k(x) for k)`. This is the density term used in extended
 likelihood fits where the fitted parameters are component yields.
 
-Yields must be non-negative and have the same length as `components`.
-Use `MixtureModel(model)` to convert to the corresponding normalized mixture.
+Yields must have the same non-empty length as `components`. Use `model(x)` to
+evaluate the extended density and `MixtureModel(model)` to convert to the
+corresponding normalized mixture.
 """
 struct ExtendedMixtureModel{
     VF<:VariateForm,
     VS<:ValueSupport,
     C<:Distribution,
     T<:Real,
-} <: Distribution{VF,VS}
+}
     components::Vector{C}
     yields::Vector{T}
 
     function ExtendedMixtureModel{VF,VS,C,T}(components::Vector{C}, yields::Vector{T}) where {VF,VS,C,T}
         length(components) == length(yields) ||
             throw(ArgumentError("ExtendedMixtureModel: $(length(components)) components vs $(length(yields)) yields"))
+        !isempty(components) ||
+            throw(ArgumentError("ExtendedMixtureModel: components and yields must be non-empty"))
         return new{VF,VS,C,T}(components, yields)
     end
 end
 
 function ExtendedMixtureModel(components::AbstractVector{C}, yields::AbstractVector{<:Real}) where {C<:Distribution}
     length(components) == length(yields) || throw(ArgumentError("ExtendedMixtureModel: length mismatch"))
-    any(y -> y < zero(y), yields) && throw(ArgumentError("ExtendedMixtureModel: yields must be non-negative"))
+    !isempty(components) || throw(ArgumentError("ExtendedMixtureModel: components and yields must be non-empty"))
 
     VF = Distributions.variate_form(C)
     VS = Distributions.value_support(C)
@@ -79,36 +82,26 @@ function (::Type{MixtureModel})(d::ExtendedMixtureModel)
     return MixtureModel(components(d), yields(d) ./ total)
 end
 
-function Distributions.pdf(d::ExtendedMixtureModel{Univariate}, x::Real)
+function (d::ExtendedMixtureModel{Univariate})(x::Real)
     return sum(y * pdf(component(d, i), x) for (i, y) in enumerate(yields(d)) if !iszero(y))
 end
 
-function Distributions.pdf(d::ExtendedMixtureModel{Multivariate}, x::AbstractVector{<:Real})
+function (d::ExtendedMixtureModel{Multivariate})(x::AbstractVector{<:Real})
     return sum(y * pdf(component(d, i), x) for (i, y) in enumerate(yields(d)) if !iszero(y))
-end
-
-function Distributions.logpdf(d::ExtendedMixtureModel{Univariate}, x::Real)
-    density = pdf(d, x)
-    return density <= zero(density) ? -Inf : log(density)
-end
-
-function Distributions.logpdf(d::ExtendedMixtureModel{Multivariate}, x::AbstractVector{<:Real})
-    density = pdf(d, x)
-    return density <= zero(density) ? -Inf : log(density)
 end
 
 """
     extended_negative_log_likelihood(model, data)
 
-Evaluate `-sum(logpdf(model, x) for x in data) + total_yield(model)`.
+Evaluate `-sum(log(model(x)) for x in data) + total_yield(model)`.
 For multivariate models, an `AbstractMatrix` is interpreted column-wise.
 """
 function extended_negative_log_likelihood(d::ExtendedMixtureModel, data)
     nll = zero(float(total_yield(d)))
     for x in data
-        lp = logpdf(d, x)
-        isfinite(lp) || return oftype(nll, Inf)
-        nll -= lp
+        density = d(x)
+        density > zero(density) || return oftype(nll, Inf)
+        nll -= log(density)
     end
     return nll + total_yield(d)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,4 +11,5 @@ using Test
     include("test-double-sided-bifurcated-crystal-ball-das.jl")
     include("test-constructor-promotion.jl")
     include("test-logpdf-interface.jl")
+    include("test-extended-mixture-model.jl")
 end

--- a/test/test-extended-mixture-model.jl
+++ b/test/test-extended-mixture-model.jl
@@ -3,6 +3,15 @@ using Distributions
 using LinearAlgebra
 using Test
 
+function test_bounds(model, expected_min, expected_max)
+    @test minimum(model) == expected_min
+    @test maximum(model) == expected_max
+    expected_support = expected_min isa AbstractVector ?
+        Distributions.RealInterval.(expected_min, expected_max) :
+        Distributions.RealInterval(expected_min, expected_max)
+    @test support(model) == expected_support
+end
+
 @testset "ExtendedMixtureModel" begin
     components = [Normal(-1.0, 0.5), Normal(1.0, 0.25)]
     ys = [20, 5]
@@ -21,9 +30,8 @@ using Test
     @test !hasmethod(pdf, Tuple{typeof(model), typeof(x)})
 
     normalized = MixtureModel(model)
-    normalized_from_pipe = model |> MixtureModel
     @test pdf(normalized, x) ≈ expected_density / total_yield(model)
-    @test probs(normalized_from_pipe) ≈ yields(model) ./ total_yield(model)
+    @test probs(normalized) ≈ yields(model) ./ total_yield(model)
 
     data = [-1.0, -0.5, 0.9]
     expected_nll = -sum(log(model(xi)) for xi in data) + total_yield(model)
@@ -60,29 +68,18 @@ end
     background = product_distribution([Uniform(-2.0, 2.0), Normal(1.0, 1.5)])
     mixed = MixtureModel([signal, swapped], [0.25, 0.75])
 
-    model = ExtendedMixtureModel([signal, mixed, background], [10.0, 5.0, 2.0])
-    @test minimum(model) == [-Inf, -Inf]
-    @test maximum(model) == [Inf, Inf]
-    @test support(model) == Distributions.RealInterval.(minimum(model), maximum(model))
-    @test all(minimum(model) .== getproperty.(support(model), :lb))
-    @test all(maximum(model) .== getproperty.(support(model), :ub))
+    test_bounds(
+        ExtendedMixtureModel([signal, mixed, background], [10.0, 5.0, 2.0]),
+        [-Inf, -Inf],
+        [Inf, Inf],
+    )
 
     finite_product = product_distribution([Uniform(-2.0, 2.0), Uniform(0.0, 1.0)])
-    finite_model = ExtendedMixtureModel([finite_product], [1.0])
-    @test minimum(finite_model) == [-2.0, 0.0]
-    @test maximum(finite_model) == [2.0, 1.0]
-    @test support(finite_model) == Distributions.RealInterval.([-2.0, 0.0], [2.0, 1.0])
-    @test all(minimum(finite_model) .== getproperty.(support(finite_model), :lb))
-    @test all(maximum(finite_model) .== getproperty.(support(finite_model), :ub))
+    test_bounds(ExtendedMixtureModel([finite_product], [1.0]), [-2.0, 0.0], [2.0, 1.0])
 
-    gaussian_product = product_distribution([Normal(-1.0, 0.5), Normal(1.0, 1.5)])
-    gaussian_model = ExtendedMixtureModel([gaussian_product], [10.0])
-    @test support(gaussian_model) == Distributions.RealInterval.([-Inf, -Inf], [Inf, Inf])
-
-    univariate_model = ExtendedMixtureModel([Normal(-1.0, 0.5), Uniform(-2.0, 2.0)], [3.0, 1.0])
-    @test minimum(univariate_model) == -Inf
-    @test maximum(univariate_model) == Inf
-    @test support(univariate_model) == Distributions.RealInterval(-Inf, Inf)
-    @test minimum(univariate_model) == support(univariate_model).lb
-    @test maximum(univariate_model) == support(univariate_model).ub
+    test_bounds(
+        ExtendedMixtureModel([Normal(-1.0, 0.5), Uniform(-2.0, 2.0)], [3.0, 1.0]),
+        -Inf,
+        Inf,
+    )
 end

--- a/test/test-extended-mixture-model.jl
+++ b/test/test-extended-mixture-model.jl
@@ -1,0 +1,74 @@
+using DistributionsHEP
+using Distributions
+using LinearAlgebra
+using Test
+
+@testset "ExtendedMixtureModel" begin
+    components = [Normal(-1.0, 0.5), Normal(1.0, 0.25)]
+    ys = [20, 5]
+    model = ExtendedMixtureModel(components, ys)
+
+    @test model isa ContinuousUnivariateDistribution
+    @test ncomponents(model) == 2
+    @test Distributions.components(model) == components
+    @test component(model, 2) == components[2]
+    @test Distributions.component_type(model) == Normal{Float64}
+    @test yields(model) == [20.0, 5.0]
+    @test total_yield(model) == 25.0
+
+    x = 0.1
+    expected_density = 20.0 * pdf(components[1], x) + 5.0 * pdf(components[2], x)
+    @test pdf(model, x) ≈ expected_density
+    @test logpdf(model, x) ≈ log(expected_density)
+
+    normalized = MixtureModel(model)
+    @test pdf(normalized, x) ≈ expected_density / total_yield(model)
+
+    data = [-1.0, -0.5, 0.9]
+    expected_nll = -sum(logpdf(model, xi) for xi in data) + total_yield(model)
+    @test extended_negative_log_likelihood(model, data) ≈ expected_nll
+
+    @test_throws ArgumentError ExtendedMixtureModel(components, [1.0])
+    @test_throws ArgumentError ExtendedMixtureModel(components, [1.0, -1.0])
+    @test_throws ArgumentError MixtureModel(ExtendedMixtureModel(components, [0.0, 0.0]))
+end
+
+@testset "ExtendedMixtureModel multivariate" begin
+    components = [
+        MvNormal([0.0, 0.0], Diagonal([1.0, 1.0])),
+        MvNormal([1.0, 1.0], Diagonal([0.25, 0.25])),
+    ]
+    model = ExtendedMixtureModel(components, [3.0, 7.0])
+
+    @test model isa MultivariateDistribution
+    @test length(model) == 2
+
+    x = [0.2, 0.4]
+    expected_density = 3.0 * pdf(components[1], x) + 7.0 * pdf(components[2], x)
+    @test pdf(model, x) ≈ expected_density
+    @test logpdf(model, x) ≈ log(expected_density)
+
+    data = hcat([0.2, 0.4], [1.0, 1.1])
+    expected_nll = -sum(logpdf(model, col) for col in eachcol(data)) + total_yield(model)
+    @test extended_negative_log_likelihood(model, data) ≈ expected_nll
+end
+
+@testset "ExtendedMixtureModel marginalization" begin
+    signal = product_distribution([Normal(-1.0, 0.5), Exponential(2.0)])
+    swapped = product_distribution([Exponential(2.0), Normal(-1.0, 0.5)])
+    background = product_distribution([Uniform(-2.0, 2.0), Normal(1.0, 1.5)])
+    mixed = MixtureModel([signal, swapped], [0.25, 0.75])
+    model = ExtendedMixtureModel([signal, mixed, background], [10.0, 5.0, 2.0])
+
+    m1 = marginalize(model, 1)
+    @test m1 isa ContinuousUnivariateDistribution
+    @test yields(m1) == yields(model)
+    @test total_yield(m1) == total_yield(model)
+
+    x = 0.2
+    expected_density =
+        10.0 * pdf(marginalize(signal, 1), x) +
+        5.0 * pdf(marginalize(mixed, 1), x) +
+        2.0 * pdf(marginalize(background, 1), x)
+    @test pdf(m1, x) ≈ expected_density
+end

--- a/test/test-extended-mixture-model.jl
+++ b/test/test-extended-mixture-model.jl
@@ -53,24 +53,3 @@ end
     expected_nll = -sum(log(model(col)) for col in eachcol(data)) + total_yield(model)
     @test extended_negative_log_likelihood(model, data) ≈ expected_nll
 end
-
-@testset "ExtendedMixtureModel marginalization" begin
-    @test !(:marginalize in names(DistributionsHEP))
-
-    signal = product_distribution([Normal(-1.0, 0.5), Exponential(2.0)])
-    swapped = product_distribution([Exponential(2.0), Normal(-1.0, 0.5)])
-    background = product_distribution([Uniform(-2.0, 2.0), Normal(1.0, 1.5)])
-    mixed = MixtureModel([signal, swapped], [0.25, 0.75])
-    model = ExtendedMixtureModel([signal, mixed, background], [10.0, 5.0, 2.0])
-
-    m1 = DistributionsHEP.marginalize(model, 1)
-    @test yields(m1) == yields(model)
-    @test total_yield(m1) == total_yield(model)
-
-    x = 0.2
-    expected_density =
-        10.0 * pdf(DistributionsHEP.marginalize(signal, 1), x) +
-        5.0 * pdf(DistributionsHEP.marginalize(mixed, 1), x) +
-        2.0 * pdf(DistributionsHEP.marginalize(background, 1), x)
-    @test m1(x) ≈ expected_density
-end

--- a/test/test-extended-mixture-model.jl
+++ b/test/test-extended-mixture-model.jl
@@ -8,7 +8,6 @@ using Test
     ys = [20, 5]
     model = ExtendedMixtureModel(components, ys)
 
-    @test model isa ContinuousUnivariateDistribution
     @test ncomponents(model) == 2
     @test Distributions.components(model) == components
     @test component(model, 2) == components[2]
@@ -18,18 +17,22 @@ using Test
 
     x = 0.1
     expected_density = 20.0 * pdf(components[1], x) + 5.0 * pdf(components[2], x)
-    @test pdf(model, x) ≈ expected_density
-    @test logpdf(model, x) ≈ log(expected_density)
+    @test model(x) ≈ expected_density
+    @test !hasmethod(pdf, Tuple{typeof(model), typeof(x)})
 
     normalized = MixtureModel(model)
+    normalized_from_pipe = model |> MixtureModel
     @test pdf(normalized, x) ≈ expected_density / total_yield(model)
+    @test probs(normalized_from_pipe) ≈ yields(model) ./ total_yield(model)
 
     data = [-1.0, -0.5, 0.9]
-    expected_nll = -sum(logpdf(model, xi) for xi in data) + total_yield(model)
+    expected_nll = -sum(log(model(xi)) for xi in data) + total_yield(model)
     @test extended_negative_log_likelihood(model, data) ≈ expected_nll
 
     @test_throws ArgumentError ExtendedMixtureModel(components, [1.0])
-    @test_throws ArgumentError ExtendedMixtureModel(components, [1.0, -1.0])
+    @test_throws ArgumentError ExtendedMixtureModel(Normal{Float64}[], Float64[])
+    @test yields(ExtendedMixtureModel(components, [1.0, -1.0])) == [1.0, -1.0]
+    @test_throws DomainError MixtureModel(ExtendedMixtureModel(components, [2.0, -1.0]))
     @test_throws ArgumentError MixtureModel(ExtendedMixtureModel(components, [0.0, 0.0]))
 end
 
@@ -40,35 +43,34 @@ end
     ]
     model = ExtendedMixtureModel(components, [3.0, 7.0])
 
-    @test model isa MultivariateDistribution
     @test length(model) == 2
 
     x = [0.2, 0.4]
     expected_density = 3.0 * pdf(components[1], x) + 7.0 * pdf(components[2], x)
-    @test pdf(model, x) ≈ expected_density
-    @test logpdf(model, x) ≈ log(expected_density)
+    @test model(x) ≈ expected_density
 
     data = hcat([0.2, 0.4], [1.0, 1.1])
-    expected_nll = -sum(logpdf(model, col) for col in eachcol(data)) + total_yield(model)
+    expected_nll = -sum(log(model(col)) for col in eachcol(data)) + total_yield(model)
     @test extended_negative_log_likelihood(model, data) ≈ expected_nll
 end
 
 @testset "ExtendedMixtureModel marginalization" begin
+    @test !(:marginalize in names(DistributionsHEP))
+
     signal = product_distribution([Normal(-1.0, 0.5), Exponential(2.0)])
     swapped = product_distribution([Exponential(2.0), Normal(-1.0, 0.5)])
     background = product_distribution([Uniform(-2.0, 2.0), Normal(1.0, 1.5)])
     mixed = MixtureModel([signal, swapped], [0.25, 0.75])
     model = ExtendedMixtureModel([signal, mixed, background], [10.0, 5.0, 2.0])
 
-    m1 = marginalize(model, 1)
-    @test m1 isa ContinuousUnivariateDistribution
+    m1 = DistributionsHEP.marginalize(model, 1)
     @test yields(m1) == yields(model)
     @test total_yield(m1) == total_yield(model)
 
     x = 0.2
     expected_density =
-        10.0 * pdf(marginalize(signal, 1), x) +
-        5.0 * pdf(marginalize(mixed, 1), x) +
-        2.0 * pdf(marginalize(background, 1), x)
-    @test pdf(m1, x) ≈ expected_density
+        10.0 * pdf(DistributionsHEP.marginalize(signal, 1), x) +
+        5.0 * pdf(DistributionsHEP.marginalize(mixed, 1), x) +
+        2.0 * pdf(DistributionsHEP.marginalize(background, 1), x)
+    @test m1(x) ≈ expected_density
 end

--- a/test/test-extended-mixture-model.jl
+++ b/test/test-extended-mixture-model.jl
@@ -53,3 +53,54 @@ end
     expected_nll = -sum(log(model(col)) for col in eachcol(data)) + total_yield(model)
     @test extended_negative_log_likelihood(model, data) ≈ expected_nll
 end
+
+@testset "ExtendedMixtureModel support" begin
+    gaussian_product = product_distribution([Normal(-1.0, 0.5), Normal(1.0, 1.5)])
+    @test gaussian_product isa MvNormal
+    @test minimum(gaussian_product) == [-Inf, -Inf]
+    @test maximum(gaussian_product) == [Inf, Inf]
+    @test support(gaussian_product) == Distributions.RealInterval.(minimum(gaussian_product), maximum(gaussian_product))
+    @test all(minimum(gaussian_product) .== getproperty.(support(gaussian_product), :lb))
+    @test all(maximum(gaussian_product) .== getproperty.(support(gaussian_product), :ub))
+
+    signal = product_distribution([Normal(-1.0, 0.5), Exponential(2.0)])
+    swapped = product_distribution([Exponential(2.0), Normal(-1.0, 0.5)])
+    background = product_distribution([Uniform(-2.0, 2.0), Normal(1.0, 1.5)])
+    @test minimum(signal) == [-Inf, 0.0]
+    @test maximum(signal) == [Inf, Inf]
+    @test support(signal) == Distributions.RealInterval.(minimum(signal), maximum(signal))
+    @test all(minimum(signal) .== getproperty.(support(signal), :lb))
+    @test all(maximum(signal) .== getproperty.(support(signal), :ub))
+
+    mixed = MixtureModel([signal, swapped], [0.25, 0.75])
+    @test minimum(mixed) == [-Inf, -Inf]
+    @test maximum(mixed) == [Inf, Inf]
+    @test support(mixed) == Distributions.RealInterval.(minimum(mixed), maximum(mixed))
+    @test all(minimum(mixed) .== getproperty.(support(mixed), :lb))
+    @test all(maximum(mixed) .== getproperty.(support(mixed), :ub))
+
+    model = ExtendedMixtureModel([signal, mixed, background], [10.0, 5.0, 2.0])
+    @test minimum(model) == [-Inf, -Inf]
+    @test maximum(model) == [Inf, Inf]
+    @test support(model) == Distributions.RealInterval.(minimum(model), maximum(model))
+    @test all(minimum(model) .== getproperty.(support(model), :lb))
+    @test all(maximum(model) .== getproperty.(support(model), :ub))
+
+    finite_product = product_distribution([Uniform(-2.0, 2.0), Uniform(0.0, 1.0)])
+    finite_model = ExtendedMixtureModel([finite_product], [1.0])
+    @test minimum(finite_model) == [-2.0, 0.0]
+    @test maximum(finite_model) == [2.0, 1.0]
+    @test support(finite_model) == Distributions.RealInterval.([-2.0, 0.0], [2.0, 1.0])
+    @test all(minimum(finite_model) .== getproperty.(support(finite_model), :lb))
+    @test all(maximum(finite_model) .== getproperty.(support(finite_model), :ub))
+
+    gaussian_model = ExtendedMixtureModel([gaussian_product], [10.0])
+    @test support(gaussian_model) == support(gaussian_product)
+
+    univariate_model = ExtendedMixtureModel([Normal(-1.0, 0.5), Uniform(-2.0, 2.0)], [3.0, 1.0])
+    @test minimum(univariate_model) == -Inf
+    @test maximum(univariate_model) == Inf
+    @test support(univariate_model) == Distributions.RealInterval(-Inf, Inf)
+    @test minimum(univariate_model) == support(univariate_model).lb
+    @test maximum(univariate_model) == support(univariate_model).ub
+end

--- a/test/test-extended-mixture-model.jl
+++ b/test/test-extended-mixture-model.jl
@@ -3,6 +3,8 @@ using Distributions
 using LinearAlgebra
 using Test
 
+import DistributionsHEP: total_yield, yields
+
 function test_bounds(model, expected_min, expected_max)
     @test minimum(model) == expected_min
     @test maximum(model) == expected_max

--- a/test/test-extended-mixture-model.jl
+++ b/test/test-extended-mixture-model.jl
@@ -26,6 +26,9 @@ end
     @test yields(model) == [20.0, 5.0]
     @test total_yield(model) == 25.0
 
+    float32_model = ExtendedMixtureModel(components, Float32[20, 5])
+    @test yields(float32_model) == Float32[20, 5]
+
     x = 0.1
     expected_density = 20.0 * pdf(components[1], x) + 5.0 * pdf(components[2], x)
     @test model(x) ≈ expected_density

--- a/test/test-extended-mixture-model.jl
+++ b/test/test-extended-mixture-model.jl
@@ -55,29 +55,10 @@ end
 end
 
 @testset "ExtendedMixtureModel support" begin
-    gaussian_product = product_distribution([Normal(-1.0, 0.5), Normal(1.0, 1.5)])
-    @test gaussian_product isa MvNormal
-    @test minimum(gaussian_product) == [-Inf, -Inf]
-    @test maximum(gaussian_product) == [Inf, Inf]
-    @test support(gaussian_product) == Distributions.RealInterval.(minimum(gaussian_product), maximum(gaussian_product))
-    @test all(minimum(gaussian_product) .== getproperty.(support(gaussian_product), :lb))
-    @test all(maximum(gaussian_product) .== getproperty.(support(gaussian_product), :ub))
-
     signal = product_distribution([Normal(-1.0, 0.5), Exponential(2.0)])
     swapped = product_distribution([Exponential(2.0), Normal(-1.0, 0.5)])
     background = product_distribution([Uniform(-2.0, 2.0), Normal(1.0, 1.5)])
-    @test minimum(signal) == [-Inf, 0.0]
-    @test maximum(signal) == [Inf, Inf]
-    @test support(signal) == Distributions.RealInterval.(minimum(signal), maximum(signal))
-    @test all(minimum(signal) .== getproperty.(support(signal), :lb))
-    @test all(maximum(signal) .== getproperty.(support(signal), :ub))
-
     mixed = MixtureModel([signal, swapped], [0.25, 0.75])
-    @test minimum(mixed) == [-Inf, -Inf]
-    @test maximum(mixed) == [Inf, Inf]
-    @test support(mixed) == Distributions.RealInterval.(minimum(mixed), maximum(mixed))
-    @test all(minimum(mixed) .== getproperty.(support(mixed), :lb))
-    @test all(maximum(mixed) .== getproperty.(support(mixed), :ub))
 
     model = ExtendedMixtureModel([signal, mixed, background], [10.0, 5.0, 2.0])
     @test minimum(model) == [-Inf, -Inf]
@@ -94,8 +75,9 @@ end
     @test all(minimum(finite_model) .== getproperty.(support(finite_model), :lb))
     @test all(maximum(finite_model) .== getproperty.(support(finite_model), :ub))
 
+    gaussian_product = product_distribution([Normal(-1.0, 0.5), Normal(1.0, 1.5)])
     gaussian_model = ExtendedMixtureModel([gaussian_product], [10.0])
-    @test support(gaussian_model) == support(gaussian_product)
+    @test support(gaussian_model) == Distributions.RealInterval.([-Inf, -Inf], [Inf, Inf])
 
     univariate_model = ExtendedMixtureModel([Normal(-1.0, 0.5), Uniform(-2.0, 2.0)], [3.0, 1.0])
     @test minimum(univariate_model) == -Inf


### PR DESCRIPTION
## Summary
This PR adds `ExtendedMixtureModel`, a small distribution helper for extended likelihood fits where component weights are expected event yields rather than normalized mixture fractions.

The motivating use case came from the 2D fit work in BuildConstructors.jl. There, the fitted parameters are `y_phiphi`, `y_mixed`, and `y_kkkk`, and the model density is

```math
f_{ext}(x) = \sum_k y_k f_k(x)
```

with extended negative log-likelihood

```math
-\sum_i \log f_{ext}(x_i) + \sum_k y_k.
```

`Distributions.MixtureModel` is not a direct fit for this because its weights are probabilities and are normalized to fractions. Extended fits need to preserve the absolute yield scale during density evaluation.

Closes #50.

## Calling the model

`ExtendedMixtureModel` follows much of the `Distributions.jl` vocabulary (`components`, `ncomponents`, `support`, `minimum`, `maximum`, `length`, …), but it is **not** a drop-in replacement for a normalized `MixtureModel` at the density API.

**There is no `pdf(model, x)` or `logpdf(model, x)`.** The extended density is evaluated by calling the model directly:

```julia
using Distributions
using DistributionsHEP

components = [Normal(-1.0, 0.5), Normal(1.0, 0.25)]
model = ExtendedMixtureModel(components, [20.0, 5.0])

x = 0.1
density = model(x)   # sum_k y_k * pdf(component(model, k), x)
```

For multivariate components, pass a coordinate vector:

```julia
model([0.2, 0.4])
```

To use the usual `pdf` / `logpdf` interface, convert to a normalized mixture first:

```julia
normalized = MixtureModel(model)
pdf(normalized, x)   # model(x) / total_yield(model)
```

For fitting, `extended_negative_log_likelihood(model, data)` applies the standard extended NLL using `model(x)` internally:

```julia
extended_negative_log_likelihood(model, data)
# -sum(log(model(x) for x in data)) + total_yield(model)
```

## Implemented Interface
- `ExtendedMixtureModel(components, yields)`: construct a distribution from components and yields.
- `model(x)`: evaluate the yield-weighted extended density (univariate `x::Real` or multivariate `x::AbstractVector`).
- `yields` / `total_yield`: expose the expected event counts and their sum.
- `extended_negative_log_likelihood`: extended NLL built from `model(x)`.
- `support`, `minimum`, `maximum`: component-wise bounds for nested product and mixture models.
- `ncomponents`, `components`, `component`, `component_type`: match the component-introspection vocabulary used by `Distributions.MixtureModel`.
- `MixtureModel(model)`: convert to the corresponding normalized mixture when `pdf` / `logpdf` are needed.
- `length(model)`: multivariate dimension query.

## Interface Justification
The minimal functionality needed by the motivating fit is construction, `model(x)`, and `total_yield`: those are enough to write the extended likelihood. We deliberately omit `pdf` / `logpdf` on `ExtendedMixtureModel` itself so the yield-weighted density is not silently treated as a normalized probability density.

`extended_negative_log_likelihood` is included because every user of this helper otherwise has to repeat the same formula and data iteration. It keeps the sign convention and the Poisson extended term next to the distribution type, while still remaining small and transparent.

`support`, `minimum`, and `maximum` are included because multivariate fit models are built from nested products and mixtures. These methods return the per-dimension union of component bounds and are tested for consistency with the rest of the package.

The component accessors are not needed for the likelihood formula itself, but they are the standard `Distributions.jl` mixture vocabulary. Keeping them makes this type inspectable in the same way as `MixtureModel` and avoids forcing users to reach into fields.

`MixtureModel(model)` is also not required for fitting, but it is useful and unambiguous: divide yields by `total_yield(model)` to get the ordinary normalized mixture. This gives users an explicit bridge for diagnostics, sampling, or APIs that require a normalized `MixtureModel`.

The implementation intentionally does not subtype `AbstractMixtureModel` and does not define `probs`. In `Distributions.jl`, `probs` means normalized prior probabilities. Exposing yields through that interface would be misleading, while normalizing them implicitly would lose the central feature of this model.

## Follow-up: coordinate marginalization
One-dimensional projections via `marginalize(model, k)` are tracked in #53 (merge after this PR lands).

## Tests
- `julia --project=. -e 'using Pkg; Pkg.test()'`