### PR TITLE
Fix C¹ tail matching for CrystalBall and DoubleCrystalBall when σ ≠ 1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DistributionsHEP"
 uuid = "0d0d6f60-fb7b-48ca-90bb-e14e8b1655a7"
 authors = ["Pere Mato <pere.mato@cern.ch>", "Mikhail Mikhasenko <mikhail.mikhasenko@cern.ch>"]
-version = "0.6.0"
+version = "0.6.1"
 
 [deps]
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"

--- a/docs/CrystalBallMath.md
+++ b/docs/CrystalBallMath.md
@@ -121,7 +121,7 @@ $$
 The implementation uses a unified `CrystalBallTail` structure parameterized by:
 - `G_x0`: The core PDF value at the transition point
 - `N`: The power-law exponent
-- `L_x0`: The logarithmic derivative at the transition point ($\alpha$ for left tail, $-\alpha$ for right tail)
+- `L_x0`: The logarithmic derivative of the core PDF at the transition point in absolute coordinates ($\alpha/\sigma$ for a left tail on a Normal core, $-\alpha/\sigma$ for a right tail)
 - `x0`: The absolute transition point
 
 This approach simplifies the formulas and makes the implementation more general, allowing the same tail structure to work with different core distributions.

--- a/docs/CrystalBallMath.md
+++ b/docs/CrystalBallMath.md
@@ -12,18 +12,29 @@ This document contains the essential mathematical formulas for the Crystal Ball 
 - $\alpha > 0$: transition point (in units of $\sigma$)
 - $n > 1$: power-law exponent
 
-### PDF Definition
+### PDF Definition (standardized coordinates)
 
-Let $x_0 = \mu - \alpha \sigma$ be the transition point, and define $\text{offset} = x - x_0$.
+Let $\hat{x} = (x - \mu)/\sigma$ and $x_0 = \mu - \alpha \sigma$ (so $\hat{x}_0 = -\alpha$).
 
 $$
 f(x) = N \begin{cases}
-    G(x_0) \left(\frac{n}{n - \alpha \cdot \text{offset}}\right)^n & \text{for } x \leq x_0 \\
-    \text{pdf}(\text{Normal}(\mu, \sigma), x) & \text{for } x > x_0
+    A\,(B - \hat{x})^{-n} & \text{for } \hat{x} \leq -\alpha \\
+    \exp\!\left(-\dfrac{\hat{x}^2}{2}\right) & \text{for } \hat{x} > -\alpha
 \end{cases}
 $$
 
-where $G(x_0) = \text{pdf}(\text{Normal}(\mu, \sigma), x_0)$ is the Gaussian PDF value at the transition point.
+with $A = (\tfrac{n}{\alpha})^n \exp(-\alpha^2/2)$ and $B = \tfrac{n}{\alpha} - \alpha$, chosen so that $f$ and $df/dx$ are continuous at $\hat{x} = -\alpha$. The overall constant $N$ normalizes $\int_{-\infty}^{\infty} f(x)\,dx = 1$.
+
+### Equivalent implementation form (absolute coordinates)
+
+Define $\text{offset} = x - x_0$ and $G(x_0) = \mathrm{pdf}(\mathcal{N}(\mu,\sigma), x_0)$. The left tail is
+
+$$
+f(x) = N\,G(x_0)\left(\frac{n}{n - L_{x_0}\,\text{offset}}\right)^n,
+\qquad x \leq x_0,
+$$
+
+where $L_{x_0} = \left.\dfrac{d}{dx}\ln G(x)\right|_{x_0} = \dfrac{\alpha}{\sigma}$ for a Normal core.
 
 ### Normalization Constant
 
@@ -32,15 +43,15 @@ N = \frac{1}{I_{\text{tail}} + I_{\text{core}}}
 $$
 
 where:
-- $I_{\text{tail}} = \frac{G(x_0)}{\alpha} \cdot \frac{n}{n-1}$
-- $I_{\text{core}} = 1 - \text{cdf}(\text{Normal}(\mu, \sigma), x_0)$
+- $I_{\text{tail}} = \dfrac{G(x_0)}{L_{x_0}} \cdot \dfrac{n}{n-1} = \dfrac{G(x_0)\,\sigma}{\alpha}\cdot\dfrac{n}{n-1}$
+- $I_{\text{core}} = 1 - \mathrm{cdf}(\mathcal{N}(\mu, \sigma), x_0)$
 
 ### CDF
 
 $$
 F(x) = N \begin{cases}
-    \frac{G(x_0)}{\alpha} \cdot \frac{n}{n-1} \cdot \left(\frac{n - \alpha \cdot \text{offset}}{n}\right)^{1-n} & \text{for } x \leq x_0 \\
-    I_{\text{tail}} + \left[\text{cdf}(\text{Normal}(\mu, \sigma), x) - \text{cdf}(\text{Normal}(\mu, \sigma), x_0)\right] & \text{for } x > x_0
+    \dfrac{G(x_0)}{L_{x_0}} \cdot \dfrac{n}{n-1} \cdot \left(\dfrac{n - L_{x_0}\,\text{offset}}{n}\right)^{1-n} & \text{for } x \leq x_0 \\
+    I_{\text{tail}} + \left[\mathrm{cdf}(\mathcal{N}(\mu, \sigma), x) - \mathrm{cdf}(\mathcal{N}(\mu, \sigma), x_0)\right] & \text{for } x > x_0
 \end{cases}
 $$
 
@@ -50,8 +61,8 @@ For $p \in [0, 1]$:
 
 $$
 Q(p) = \begin{cases}
-    x_0 + \frac{n}{\alpha} \left(1 - \left(\frac{p / N}{I_{\text{tail}} / N}\right)^{1/(1-n)}\right) & \text{for } p \leq F(x_0) \\
-    \text{quantile}\left(\text{Normal}(\mu, \sigma), \frac{p - F(x_0)}{N} + \text{cdf}(\text{Normal}(\mu, \sigma), x_0)\right) & \text{for } p > F(x_0)
+    x_0 + \dfrac{n}{L_{x_0}} \left(1 - \left(\dfrac{p / N}{I_{\text{tail}} / N}\right)^{1/(1-n)}\right) & \text{for } p \leq F(x_0) \\
+    \mathrm{quantile}\!\left(\mathcal{N}(\mu, \sigma), \dfrac{p - F(x_0)}{N} + \mathrm{cdf}(\mathcal{N}(\mu, \sigma), x_0)\right) & \text{for } p > F(x_0)
 \end{cases}
 $$
 
@@ -65,21 +76,37 @@ $$
 - $\alpha_L > 0, n_L > 1$: left tail parameters
 - $\alpha_R > 0, n_R > 1$: right tail parameters
 
-### PDF Definition
+### PDF Definition (standardized coordinates)
 
-Let $x_{0L} = \mu - \alpha_L \sigma$ and $x_{0R} = \mu + \alpha_R \sigma$ be the transition points.
+Let $\hat{x} = (x - \mu)/\sigma$, $x_{0L} = \mu - \alpha_L \sigma$, and $x_{0R} = \mu + \alpha_R \sigma$.
 
 $$
 f(x) = N \begin{cases}
-    G(x_{0L}) \left(\frac{n_L}{n_L - \alpha_L \cdot (x - x_{0L})}\right)^{n_L} & \text{for } x < x_{0L} \\
-    \text{pdf}(\text{Normal}(\mu, \sigma), x) & \text{for } x_{0L} \leq x \leq x_{0R} \\
-    G(x_{0R}) \left(\frac{n_R}{n_R + \alpha_R \cdot (x - x_{0R})}\right)^{n_R} & \text{for } x > x_{0R}
+    A_L\,(B_L - \hat{x})^{-n_L} & \text{for } \hat{x} < -\alpha_L \\
+    \exp\!\left(-\dfrac{\hat{x}^2}{2}\right) & \text{for } -\alpha_L \leq \hat{x} \leq \alpha_R \\
+    A_R\,(B_R + \hat{x})^{-n_R} & \text{for } \hat{x} > \alpha_R
 \end{cases}
 $$
 
-where:
-- $G(x_{0L}) = \text{pdf}(\text{Normal}(\mu, \sigma), x_{0L})$
-- $G(x_{0R}) = \text{pdf}(\text{Normal}(\mu, \sigma), x_{0R})$
+with $A_L, B_L, A_R, B_R$ derived from $(\alpha_L, n_L, \alpha_R, n_R)$ to enforce value and first-derivative continuity at both joins (same construction as the one-sided case on each side).
+
+### Equivalent implementation form (absolute coordinates)
+
+$$
+f(x) = N \begin{cases}
+    G(x_{0L}) \left(\dfrac{n_L}{n_L - L_{L}\,(x - x_{0L})}\right)^{n_L} & \text{for } x < x_{0L} \\
+    \mathrm{pdf}(\mathcal{N}(\mu, \sigma), x) & \text{for } x_{0L} \leq x \leq x_{0R} \\
+    G(x_{0R}) \left(\dfrac{n_R}{n_R - L_{R}\,(x - x_{0R})}\right)^{n_R} & \text{for } x > x_{0R}
+\end{cases}
+$$
+
+where $G(x_{0}) = \mathrm{pdf}(\mathcal{N}(\mu,\sigma), x_{0})$ and, for a Normal core,
+
+$$
+L_L = \left.\frac{d}{dx}\ln G\right|_{x_{0L}} = \frac{\alpha_L}{\sigma},
+\qquad
+L_R = \left.\frac{d}{dx}\ln G\right|_{x_{0R}} = -\frac{\alpha_R}{\sigma}.
+$$
 
 ### Normalization Constant
 
@@ -88,29 +115,17 @@ N = \frac{1}{I_{\text{left}} + I_{\text{core}} + I_{\text{right}}}
 $$
 
 where:
-- $I_{\text{left}} = \frac{G(x_{0L})}{\alpha_L} \cdot \frac{n_L}{n_L-1}$
-- $I_{\text{core}} = \text{cdf}(\text{Normal}(\mu, \sigma), x_{0R}) - \text{cdf}(\text{Normal}(\mu, \sigma), x_{0L})$
-- $I_{\text{right}} = \frac{G(x_{0R})}{\alpha_R} \cdot \frac{n_R}{n_R-1}$
+- $I_{\text{left}} = \dfrac{G(x_{0L})}{L_L} \cdot \dfrac{n_L}{n_L-1}$
+- $I_{\text{core}} = \mathrm{cdf}(\mathcal{N}(\mu, \sigma), x_{0R}) - \mathrm{cdf}(\mathcal{N}(\mu, \sigma), x_{0L})$
+- $I_{\text{right}} = \dfrac{G(x_{0R})}{-L_R} \cdot \dfrac{n_R}{n_R-1} = \dfrac{G(x_{0R})\,\sigma}{\alpha_R}\cdot\dfrac{n_R}{n_R-1}$
 
 ### CDF
 
 $$
 F(x) = N \begin{cases}
-    \frac{G(x_{0L})}{\alpha_L} \cdot \frac{n_L}{n_L-1} \cdot \left(\frac{n_L - \alpha_L \cdot (x - x_{0L})}{n_L}\right)^{1-n_L} & \text{for } x < x_{0L} \\
-    F(x_{0L}) + \left[\text{cdf}(\text{Normal}(\mu, \sigma), x) - \text{cdf}(\text{Normal}(\mu, \sigma), x_{0L})\right] & \text{for } x_{0L} \leq x \leq x_{0R} \\
-    F(x_{0R}) - \frac{G(x_{0R})}{\alpha_R} \cdot \frac{n_R}{n_R-1} \cdot \left[\left(\frac{n_R + \alpha_R \cdot (x - x_{0R})}{n_R}\right)^{1-n_R} - 1\right] & \text{for } x > x_{0R}
-\end{cases}
-$$
-
-### Quantile (Inverse CDF)
-
-For $p \in [0, 1]$:
-
-$$
-Q(p) = \begin{cases}
-    x_{0L} + \frac{n_L}{\alpha_L} \left(1 - \left(\frac{p / N}{I_{\text{left}} / N}\right)^{1/(1-n_L)}\right) & \text{for } p \leq F(x_{0L}) \\
-    \text{quantile}\left(\text{Normal}(\mu, \sigma), \frac{p - F(x_{0L})}{N} + \text{cdf}(\text{Normal}(\mu, \sigma), x_{0L})\right) & \text{for } F(x_{0L}) < p \leq F(x_{0R}) \\
-    x_{0R} - \frac{n_R}{\alpha_R} \left(1 - \left(\frac{(p - F(x_{0R})) / N + I_{\text{right}} / N}{I_{\text{right}} / N}\right)^{1/(1-n_R)}\right) & \text{for } p > F(x_{0R})
+    \dfrac{G(x_{0L})}{L_L} \cdot \dfrac{n_L}{n_L-1} \cdot \left(\dfrac{n_L - L_L\,(x - x_{0L})}{n_L}\right)^{1-n_L} & \text{for } x < x_{0L} \\
+    F(x_{0L}) + \left[\mathrm{cdf}(\mathcal{N}(\mu, \sigma), x) - \mathrm{cdf}(\mathcal{N}(\mu, \sigma), x_{0L})\right] & \text{for } x_{0L} \leq x \leq x_{0R} \\
+    F(x_{0R}) - \dfrac{G(x_{0R})}{-L_R} \cdot \dfrac{n_R}{n_R-1} \cdot \left[\left(\dfrac{n_R - L_R\,(x - x_{0R})}{n_R}\right)^{1-n_R} - 1\right] & \text{for } x > x_{0R}
 \end{cases}
 $$
 
@@ -118,10 +133,10 @@ $$
 
 ## Implementation Notes
 
-The implementation uses a unified `CrystalBallTail` structure parameterized by:
-- `G_x0`: The core PDF value at the transition point
-- `N`: The power-law exponent
-- `L_x0`: The logarithmic derivative of the core PDF at the transition point in absolute coordinates ($\alpha/\sigma$ for a left tail on a Normal core, $-\alpha/\sigma$ for a right tail)
-- `x0`: The absolute transition point
+The code uses a unified `CrystalBallTail` structure parameterized by:
+- `G_x0`: core PDF value at the transition point ($G(x_0)$)
+- `N`: power-law exponent ($n$)
+- `L_x0`: $\left.\dfrac{d}{dx}\ln f_{\text{core}}\right|_{x_0}$ in **absolute** coordinates ($\alpha/\sigma$ on the left, $-\alpha/\sigma$ on the right for a Normal core)
+- `x0`: absolute transition point
 
-This approach simplifies the formulas and makes the implementation more general, allowing the same tail structure to work with different core distributions.
+**Important:** $L_{x_0}$ is not the same as $\alpha$ from the docstring. The standardized log-slope at the left join is $\left.\dfrac{d}{d\hat{x}}\ln f\right|_{\hat{x}=-\alpha} = \alpha$, while the absolute log-slope is $L_{x_0} = \alpha/\sigma$. Confusing the two breaks $C^1$ matching whenever $\sigma \neq 1$.

--- a/src/crystal-ball-tail.jl
+++ b/src/crystal-ball-tail.jl
@@ -5,9 +5,11 @@
 struct CrystalBallTail{T<:Real}
     G_x0::T       # G(x0): Core PDF at transition point x0
     N::T          # Effective power
-    L_x0::T       # L(x0): Logarithmic derivative of core PDF at transition point x0
+    L_x0::T       # L(x0): d ln pdf / dx at transition point x0 (absolute coordinates)
     x0::T         # x0: Absolute transition point
 end
+
+_log_derivative_normal(d::Normal{T}, x::Real) where {T<:Real} = -(x - d.μ) / d.σ^2
 
 function _norm_const(tail::CrystalBallTail{T}) where {T<:Real}
     (; G_x0, N, L_x0) = tail

--- a/src/crystalball.jl
+++ b/src/crystalball.jl
@@ -54,7 +54,7 @@ struct CrystalBall{T<:Real} <: ContinuousUnivariateDistribution
         x0 = μ - α * σ
         # Use pdf from Normal to get normalized G_x0 at transition point
         G_x0 = pdf(gauss, x0)
-        L_x0 = α
+        L_x0 = _log_derivative_normal(gauss, x0)
         tail = CrystalBallTail(G_x0, n, L_x0, x0)
 
         tail_contribution = _integral(tail, tail.x0)

--- a/src/double-sided-crystal-ball.jl
+++ b/src/double-sided-crystal-ball.jl
@@ -63,13 +63,13 @@ struct DoubleCrystalBall{T<:Real} <: ContinuousUnivariateDistribution
         x0L = μ - αL * σ
         # Use pdf from Normal to get normalized G_x0 at transition point
         G_x0L = pdf(gauss, x0L)
-        L_x0L = αL # log derivative is just equal to αL
+        L_x0L = _log_derivative_normal(gauss, x0L)
         left_tail = CrystalBallTail(G_x0L, nL, L_x0L, x0L)
 
         x0R = μ + αR * σ
         # Use pdf from Normal to get normalized G_x0 at transition point
         G_x0R = pdf(gauss, x0R)
-        L_x0R = -αR  # Negative as should be for rightward tail
+        L_x0R = _log_derivative_normal(gauss, x0R)
         right_tail = CrystalBallTail(G_x0R, nR, L_x0R, x0R)
 
         left_tail_contribution = _integral(left_tail, left_tail.x0)
@@ -190,9 +190,9 @@ Distributions.scale(d::DoubleCrystalBall) = d.gauss.σ
 Distributions.params(d::DoubleCrystalBall) = (
     d.gauss.μ,
     d.gauss.σ,
-    d.left_tail.L_x0,
+    (d.gauss.μ - d.left_tail.x0) / d.gauss.σ,
     d.left_tail.N,
-    -d.right_tail.L_x0,  # Negative as should be for rightward tail
-    d.right_tail.N
+    (d.right_tail.x0 - d.gauss.μ) / d.gauss.σ,
+    d.right_tail.N,
 )
 Distributions.partype(::DoubleCrystalBall{T}) where {T} = T

--- a/test/crystal-ball-test-helpers.jl
+++ b/test/crystal-ball-test-helpers.jl
@@ -1,0 +1,35 @@
+# Shared checks for Crystal Ball tail matching.
+# Regression guard: #41 used L_x0 = ±α (standardized log-derivative) instead of ±α/σ
+# (absolute coordinates). That preserves pdf continuity and ∫pdf = 1, but breaks C¹
+# matching whenever σ ≠ 1.
+
+"""One-sided numerical derivative of `pdf(d, x)` near `x0`."""
+function pdf_derivative_one_sided(d, x0, side::Symbol; h=1e-7)
+    side == :left && return (pdf(d, x0 - h) - pdf(d, x0 - 2h)) / h
+    side == :right && return (pdf(d, x0 + 2h) - pdf(d, x0 + h)) / h
+    throw(ArgumentError("side must be :left or :right"))
+end
+
+"""Expected d ln pdf / dx for a Normal core at `x`."""
+gaussian_log_derivative(μ, σ, x) = -(x - μ) / σ^2
+
+"""
+    test_pdf_derivative_continuous(d, x0; rtol=1e-5)
+
+Check that the PDF has a continuous first derivative at a Gaussian–tail transition.
+"""
+function test_pdf_derivative_continuous(d, x0; rtol=1e-5)
+    deriv_left = pdf_derivative_one_sided(d, x0, :left)
+    deriv_right = pdf_derivative_one_sided(d, x0, :right)
+    @test isapprox(deriv_left, deriv_right; rtol=rtol)
+end
+
+"""
+    test_tail_log_derivative(d, tail, gauss)
+
+Check that the stored tail log-derivative matches the Gaussian core at the join.
+"""
+function test_tail_log_derivative(tail, gauss)
+    expected = gaussian_log_derivative(gauss.μ, gauss.σ, tail.x0)
+    @test isapprox(tail.L_x0, expected)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,6 +5,7 @@ using Test
     include("test-argusBG.jl")
     include("test-crystalball.jl")
     include("test-double-sided-crystal-ball.jl")
+    include("test-crystal-ball-c1-matching.jl")
     include("test-secant.jl")
     include("test-bifurcated-gaussian.jl")
     include("test-double-sided-bifurcated-crystal-ball.jl")

--- a/test/test-crystal-ball-c1-matching.jl
+++ b/test/test-crystal-ball-c1-matching.jl
@@ -1,0 +1,56 @@
+using DistributionsHEP
+using Distributions
+using Test
+
+include("crystal-ball-test-helpers.jl")
+
+@testset "Crystal Ball C¹ tail matching" verbose = true begin
+    # σ values deliberately include regimes where the #41 bug was visible (σ ≠ 1)
+    σ_values = [0.3, 0.5, 1.0, 5.0]
+
+    @testset "CrystalBall derivative continuity" begin
+        for σ in σ_values
+            @testset "σ = $σ" begin
+                d = CrystalBall(0.0, σ, 1.6, 10.0)
+                test_pdf_derivative_continuous(d, d.tail.x0)
+                test_tail_log_derivative(d.tail, d.gauss)
+            end
+        end
+    end
+
+    @testset "DoubleCrystalBall derivative continuity" begin
+        for σ in σ_values
+            @testset "σ = $σ" begin
+                d = DoubleCrystalBall(0.0, σ, 1.6, 10.0, 1.6, 10.0)
+                for tail in (d.left_tail, d.right_tail)
+                    test_pdf_derivative_continuous(d, tail.x0)
+                    test_tail_log_derivative(tail, d.gauss)
+                end
+            end
+        end
+    end
+
+    @testset "Tail exponent n affects deep tail when σ ≠ 1" begin
+        σ, α = 0.3, 1.6
+        x0L = -α * σ
+        x_deep_left = x0L - 0.5
+        x0R = α * σ
+        x_deep_right = x0R + 0.5
+
+        d_cb_low = CrystalBall(0.0, σ, α, 2.0)
+        d_cb_high = CrystalBall(0.0, σ, α, 100.0)
+        @test pdf(d_cb_high, x_deep_left) < pdf(d_cb_low, x_deep_left)
+
+        d_dcb_low = DoubleCrystalBall(0.0, σ, α, 2.0, α, 2.0)
+        d_dcb_high = DoubleCrystalBall(0.0, σ, α, 100.0, α, 100.0)
+        @test pdf(d_dcb_high, x_deep_left) < pdf(d_dcb_low, x_deep_left)
+        @test pdf(d_dcb_high, x_deep_right) < pdf(d_dcb_low, x_deep_right)
+
+        # With the #41 bug, pdf at x_deep_left was nearly identical for n = 10 vs n = 100.
+        d_n10 = DoubleCrystalBall(0.0, σ, α, 10.0, α, 10.0)
+        d_n100 = DoubleCrystalBall(0.0, σ, α, 100.0, α, 100.0)
+        rel_diff = abs(pdf(d_n10, x_deep_left) - pdf(d_n100, x_deep_left)) /
+                   pdf(d_n10, x_deep_left)
+        @test rel_diff > 0.15
+    end
+end

--- a/test/test-crystalball.jl
+++ b/test/test-crystalball.jl
@@ -29,6 +29,14 @@ using Test
         pdf_value_right = pdf(d, x_merge - 1e-5) # just below the transition point
         @test isapprox(pdf_value_left, pdf_value_right; atol=1e-5)
 
+        # First derivative should be continuous at the transition point (regression for σ ≠ 1)
+        d_scaled = CrystalBall(0.0, 0.3, 1.6, 10.0)
+        x0 = d_scaled.tail.x0
+        h = 1e-7
+        deriv_left = (pdf(d_scaled, x0 - h) - pdf(d_scaled, x0 - 2h)) / h
+        deriv_right = (pdf(d_scaled, x0 + 2h) - pdf(d_scaled, x0 + h)) / h
+        @test isapprox(deriv_left, deriv_right; rtol=1e-5)
+
         # PDF should integrate to 1
         numerical_integral = quadgk(x -> pdf(d, x), -Inf, Inf)[1]
         @test isapprox(numerical_integral, 1.0; atol=1e-7)

--- a/test/test-crystalball.jl
+++ b/test/test-crystalball.jl
@@ -4,6 +4,8 @@ using Distributions
 using QuadGK
 using Test
 
+include("crystal-ball-test-helpers.jl")
+
 @testset "CrystalBall Distribution" verbose = true begin
 
     # Test distribution with σ = 1 (standard case)
@@ -28,14 +30,6 @@ using Test
         pdf_value_left = pdf(d, x_merge + 1e-5)  # just above the transition point
         pdf_value_right = pdf(d, x_merge - 1e-5) # just below the transition point
         @test isapprox(pdf_value_left, pdf_value_right; atol=1e-5)
-
-        # First derivative should be continuous at the transition point (regression for σ ≠ 1)
-        d_scaled = CrystalBall(0.0, 0.3, 1.6, 10.0)
-        x0 = d_scaled.tail.x0
-        h = 1e-7
-        deriv_left = (pdf(d_scaled, x0 - h) - pdf(d_scaled, x0 - 2h)) / h
-        deriv_right = (pdf(d_scaled, x0 + 2h) - pdf(d_scaled, x0 + h)) / h
-        @test isapprox(deriv_left, deriv_right; rtol=1e-5)
 
         # PDF should integrate to 1
         numerical_integral = quadgk(x -> pdf(d, x), -Inf, Inf)[1]
@@ -106,6 +100,10 @@ using Test
                 @warn "PDF normalization failed for σ = $σ" numerical_integral
             end
             @test isapprox(numerical_integral, 1.0; atol=1e-6)
+
+            # C¹ matching at the tail join (guards σ-scaling regressions like #41)
+            test_pdf_derivative_continuous(d_test, d_test.tail.x0)
+            test_tail_log_derivative(d_test.tail, d_test.gauss)
         end
     end
 

--- a/test/test-double-sided-crystal-ball.jl
+++ b/test/test-double-sided-crystal-ball.jl
@@ -4,6 +4,8 @@ using Distributions
 using QuadGK
 using Test
 
+include("crystal-ball-test-helpers.jl")
+
 # Test distribution with σ = 1 (standard case)
 d = DoubleCrystalBall(0.0, 1.0, 1.5, 2.0, 2.0, 3.0)
 
@@ -34,15 +36,6 @@ d = DoubleCrystalBall(0.0, 1.0, 1.5, 2.0, 2.0, 3.0)
         pdf_value_left = pdf(d, x_right_merge - 1e-6)
         pdf_value_right = pdf(d, x_right_merge + 1e-6)
         @test isapprox(pdf_value_left, pdf_value_right; atol=1e-5)
-
-        # First derivative should be continuous at transition points (regression for σ ≠ 1)
-        d_scaled = DoubleCrystalBall(0.0, 0.3, 1.6, 10.0, 1.6, 10.0)
-        for x0 in (d_scaled.left_tail.x0, d_scaled.right_tail.x0)
-            h = 1e-7
-            deriv_left = (pdf(d_scaled, x0 - h) - pdf(d_scaled, x0 - 2h)) / h
-            deriv_right = (pdf(d_scaled, x0 + 2h) - pdf(d_scaled, x0 + h)) / h
-            @test isapprox(deriv_left, deriv_right; rtol=1e-5)
-        end
 
         # PDF should integrate to 1
         numerical_integral = quadgk(x -> pdf(d, x), -Inf, Inf)[1]
@@ -123,6 +116,12 @@ d = DoubleCrystalBall(0.0, 1.0, 1.5, 2.0, 2.0, 3.0)
             # The PDF should integrate to 1 for all σ values
             numerical_integral = quadgk(x -> pdf(d_test, x), -Inf, Inf)[1]
             @test isapprox(numerical_integral, 1.0; atol=1e-6)
+
+            # C¹ matching at both tail joins (guards σ-scaling regressions like #41)
+            for tail in (d_test.left_tail, d_test.right_tail)
+                test_pdf_derivative_continuous(d_test, tail.x0)
+                test_tail_log_derivative(tail, d_test.gauss)
+            end
         end
     end
 

--- a/test/test-double-sided-crystal-ball.jl
+++ b/test/test-double-sided-crystal-ball.jl
@@ -35,6 +35,15 @@ d = DoubleCrystalBall(0.0, 1.0, 1.5, 2.0, 2.0, 3.0)
         pdf_value_right = pdf(d, x_right_merge + 1e-6)
         @test isapprox(pdf_value_left, pdf_value_right; atol=1e-5)
 
+        # First derivative should be continuous at transition points (regression for σ ≠ 1)
+        d_scaled = DoubleCrystalBall(0.0, 0.3, 1.6, 10.0, 1.6, 10.0)
+        for x0 in (d_scaled.left_tail.x0, d_scaled.right_tail.x0)
+            h = 1e-7
+            deriv_left = (pdf(d_scaled, x0 - h) - pdf(d_scaled, x0 - 2h)) / h
+            deriv_right = (pdf(d_scaled, x0 + 2h) - pdf(d_scaled, x0 + h)) / h
+            @test isapprox(deriv_left, deriv_right; rtol=1e-5)
+        end
+
         # PDF should integrate to 1
         numerical_integral = quadgk(x -> pdf(d, x), -Inf, Inf)[1]
         @test isapprox(numerical_integral, 1.0; atol=1e-6)
@@ -167,8 +176,13 @@ d = DoubleCrystalBall(0.0, 1.0, 1.5, 2.0, 2.0, 3.0)
 
         for (μ, σ, αL, nL, αR, nR) in test_cases
             d = DoubleCrystalBall(μ, σ, αL, nL, αR, nR)
-            p = params(d)
-            @test p == (μ, σ, αL, nL, αR, nR)
+            μ_p, σ_p, αL_p, nL_p, αR_p, nR_p = params(d)
+            @test μ_p == μ
+            @test σ_p == σ
+            @test isapprox(αL_p, αL)
+            @test nL_p == nL
+            @test isapprox(αR_p, αR)
+            @test nR_p == nR
         end
 
         # Test location and scale


### PR DESCRIPTION
## Summary

Fixes a regression in #41 (`d64ec82`, Jan 2026): `CrystalBall` and `DoubleCrystalBall` lost **first-derivative continuity** at the Gaussian–tail joins for **σ ≠ 1**.

The public docstring/specification was always correct. The refactor wired the wrong log-derivative into `CrystalBallTail`.

---

## Specification (docstring — unchanged)

Standardized variable: $\hat{x} = (x-\mu)/\sigma$.

Piecewise PDF (double-sided Crystal Ball):

| region | $f(x)$ |
| --- | --- |
| $\hat{x} < -\alpha_L$ | $N\,A_L\,(B_L - \hat{x})^{-n_L}$ |
| $-\alpha_L \le \hat{x} \le \alpha_R$ | $N\,\exp(-\hat{x}^2/2)$ |
| $\hat{x} > \alpha_R$ | $N\,A_R\,(B_R + \hat{x})^{-n_R}$ |

$A_L, B_L, A_R, B_R$ enforce **value and first-derivative continuity** at $\hat{x} = \pm\alpha_{L/R}$; $N$ normalizes the PDF.

At the left join ($\hat{x} = -\alpha_L$, $x_{0L} = \mu - \alpha_L\sigma$):

```math
\left.\frac{d}{d\hat{x}}\ln f\right|_{\hat{x}=-\alpha_L} = \alpha_L
```

(standardized log-slope)

---

## Implementation (`CrystalBallTail` — absolute coordinates)

Core: `pdf(Normal(μ,σ), x)`.

Tail:

```math
f_{\mathrm{tail}}(x) = G(x_0)\left(\frac{n}{n - L_{x_0}(x-x_0)}\right)^n,
\quad G(x_0) = \mathrm{pdf}(\mathcal{N}(\mu,\sigma), x_0)
```

C¹ matching at $x_0$:

```math
\left.\frac{df}{dx}\right|_{x_0} = G(x_0)\,L_{x_0}
\;\;\Longleftrightarrow\;\;
L_{x_0} = \left.\frac{d}{dx}\ln G\right|_{x_0}
```

For a Normal core:

```math
L_{x_0} = \frac{\alpha_L}{\sigma}\ \text{(left)}, \qquad
L_{x_0} = -\frac{\alpha_R}{\sigma}\ \text{(right)}
```

**Not** $L_{x_0} = \alpha_L$ — that is the standardized log-slope, not the absolute one.

Coordinate conversion at the left join:

```math
L_{x_0} = \frac{1}{\sigma}\left.\frac{d}{d\hat{x}}\ln f\right|_{\hat{x}=-\alpha_L} = \frac{\alpha_L}{\sigma}
```

The one-sided `CrystalBall` is the same with a single left tail.

---

## Bug in #41

Constructors set

```julia
L_x0L = αL      # d ln f / d x̂  — wrong coordinate system
L_x0R = -αR
```

instead of `_log_derivative_normal(gauss, x0)` (= $\alpha/\sigma$).

| quantity | #41 (broken) | correct |
| --- | --- | --- |
| left $L_{x_0}$ | $\alpha_L$ | $\alpha_L/\sigma$ |
| right $L_{x_0}$ | $-\alpha_R$ | $-\alpha_R/\sigma$ |
| one-sided deriv ratio at join, $\sigma=0.3$ | $0.30$ / $3.33$ | $1.00$ / $1.00$ |

Invisible at $\sigma=1$ because then $\alpha/\sigma = \alpha$.

---

## Symptoms

With $\sigma=0.3$, $\alpha=1.6$, $n=10$:

- **Kink** at $x = \pm\alpha\sigma = \pm0.48$ (discontinuous $df/dx$).
- **`n` inert** in the deep tail: broken pdf at $x_{0L}-0.5$ is $0.122$ for both $n=10$ and $n=100$; fixed values are $0.033$ and $0.026$.

---

## Why existing tests did not catch this

| What was tested | Would #41 fail? |
| --- | --- |
| PDF value continuous at joins | No |
| $\int f = 1$ | No |
| CDF continuous / quantile round-trip | No (integral of a kink is still smooth) |
| `Sigma scaling` at $\sigma \in \{0.5,1,5\}$ | No — no derivative check |
| Default fixture $\sigma=1$ | No |

The suite verified a valid probability measure, not the docstring C¹ construction.

---

## Fix

1. `_log_derivative_normal(d, x) = -(x-\mu)/\sigma^2` in `crystal-ball-tail.jl`.
2. Use it in `CrystalBall` / `DoubleCrystalBall` constructors (same pattern as bifurcated CB in #41).
3. Fix `params(::DoubleCrystalBall)` to return $(\mu,\sigma,\alpha_L,n_L,\alpha_R,n_R)$.
4. Update `docs/CrystalBallMath.md` — both the $(\hat{x},A,B)$ spec and the $(L_{x_0},\mathrm{offset})$ implementation form.


<img width="900" height="1500" alt="image" src="https://github.com/user-attachments/assets/4bf3ccd2-229b-44ad-ad76-a75637b0d890" />


---

## New test coverage

- **`test/test-crystal-ball-c1-matching.jl`**: C¹ at joins for $\sigma \in \{0.3,0.5,1,5\}$; $L_{x_0}$ structural check; $n$ sensitivity at $\sigma=0.3$.
- **`Sigma scaling` loops** in both CB test files now also assert C¹ matching.

826 tests pass; the new suite **would have failed #41** for any $\sigma \neq 1$.

---

## Test plan

- [x] `Pkg.test("DistributionsHEP")`
- [x] New `Crystal Ball C¹ tail matching` testset (28 checks)
- [x] Manual plot: `DoubleCrystalBall(0, 0.3, 1.6, 10, 1.6, 10)` — smooth joins, visible $n$ dependence